### PR TITLE
Change version for the dependencies for commons-io and javax.ws.rs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.ibissource</groupId>
 	<artifactId>frank-flow</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
-	
+
 	<name>Frank!Flow</name>
 	<description>Graphical flow editor for Frank configurations</description>
 	<url>https://github.com/ibissource/frank-flow</url>
@@ -16,7 +16,7 @@
 		<name>Ibissource.org</name>
 		<url>https://ibissource.org</url>
 	</organization>
-	
+
 	<licenses>
 		<license>
 			<name>Apache License, Version 2.0</name>
@@ -87,7 +87,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.7</version>
+			<version>2.2</version>
 		</dependency>
 
 		<dependency>
@@ -101,11 +101,11 @@
 			<artifactId>jackson-jaxrs</artifactId>
 			<version>1.1.1</version>
 		</dependency>
-<!-- 		<dependency> -->
-<!-- 			<groupId>com.fasterxml.jackson.jaxrs</groupId> -->
-<!-- 			<artifactId>jackson-jaxrs-json-provider</artifactId> -->
-<!-- 			<version>2.11.2</version> -->
-<!-- 		</dependency> -->
+		<!-- 		<dependency> -->
+		<!-- 			<groupId>com.fasterxml.jackson.jaxrs</groupId> -->
+		<!-- 			<artifactId>jackson-jaxrs-json-provider</artifactId> -->
+		<!-- 			<version>2.11.2</version> -->
+		<!-- 		</dependency> -->
 
 		<dependency>
 			<groupId>org.glassfish</groupId>
@@ -122,7 +122,7 @@
 		<dependency>
 			<groupId>javax.ws.rs</groupId>
 			<artifactId>javax.ws.rs-api</artifactId>
-			<version>2.0</version>
+			<version>2.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.cxf</groupId>
@@ -252,7 +252,7 @@
 									<npmVersion>6.14.6</npmVersion>
 								</configuration>
 							</execution>
-		
+
 							<execution>
 								<phase>generate-resources</phase>
 								<id>npm install</id>
@@ -263,14 +263,14 @@
 									<arguments>install</arguments>
 								</configuration>
 							</execution>
-		
+
 							<execution>
 								<phase>generate-resources</phase>
 								<id>webpack build</id>
 								<goals>
 									<goal>webpack</goal>
 								</goals>
-								
+
 								<configuration>
 									<workingDirectory>src/frontend</workingDirectory>
 								</configuration>


### PR DESCRIPTION
This is done to prevent duplicate dependencies.
Requested by Jaco.