### PR TITLE
Fix bug where configuration (root folder) couldn't be selected

### DIFF
--- a/frank-flow/src/frontend/src/app/shared/components/file-tree/file-tree.component.ts
+++ b/frank-flow/src/frontend/src/app/shared/components/file-tree/file-tree.component.ts
@@ -71,6 +71,11 @@ export class FileTreeComponent implements AfterViewInit, OnDestroy {
         label: configuration.name,
         expanded: true,
         items: this.parseFiles(configuration.name, configuration.content),
+        value: JSON.stringify({
+          configuration: configuration.name,
+          path: '',
+          type: FileType.FOLDER,
+        }),
       })
     );
 


### PR DESCRIPTION
Added a value to the config, like the folders had.

Closes #159 