### PR TITLE
fix: close Options after a Node had been deleted

### DIFF
--- a/frank-flow/src/frontend/src/app/flow/options/options.component.ts
+++ b/frank-flow/src/frontend/src/app/flow/options/options.component.ts
@@ -239,5 +239,6 @@ export class OptionsComponent implements OnInit, OnDestroy {
 
   deleteNode() {
     this.flowStructureService.deleteNode(this.structureNode);
+    this.ngxSmartModalService.close('optionsModal');
   }
 }


### PR DESCRIPTION
Fixes #424 