### PR TITLE
fix: only show sender and listener badges

### DIFF
--- a/frank-flow/src/frontend/src/app/shared/services/node-generator.service.ts
+++ b/frank-flow/src/frontend/src/app/shared/services/node-generator.service.ts
@@ -78,9 +78,9 @@ export class NodeGeneratorService {
   }
 
   getFilteredNestedElements(nestedElements: FlowNodeNestedElements) {
-    const hiddenNestedElements = new Set(['forward']);
-    return Object.entries(nestedElements).filter(
-      ([typeGroup, _]) => !hiddenNestedElements.has(typeGroup)
+    const wantedNestedElements = new Set(['sender', 'listener']);
+    return Object.entries(nestedElements).filter(([typeGroup, _]) =>
+      wantedNestedElements.has(typeGroup)
     );
   }
 


### PR DESCRIPTION
quick fix to only show badges for listeners and senders